### PR TITLE
fix pointer reference error to interface

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -399,14 +399,14 @@ func NewOscClient(ip string, port int) (client *OscClient) {
 }
 
 // SendBundle sends an OSC Bundle or an OSC Message.
-func (client *OscClient) Send(bundle *OscPacket) (err error) {
+func (client *OscClient) Send(bundle OscPacket) (err error) {
 	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", client.ipaddress, client.port))
 	conn, err := net.DialUDP("udp", nil, addr)
 	if err != nil {
 		return err
 	}
 
-	data, err := (*bundle).ToByteArray()
+	data, err := (bundle).ToByteArray()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
As a complete newbie in Go , I´m assuming this as a fix, I´ve remove the pointer reference to OscPacket in Send method, and it seems to work
