### PR TITLE
SetLocalAddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ Open Sound Control (OSC) library for Golang. Implemented in pure Go.
 import "github.com/hypebeast/go-osc/osc"
 
 func main() {
-    remoteAddr, err := net.ResolveUDPAddr("udp", "localhost:8765")
-    if err != nil {
-       // handle err
-    }
-    client := osc.NewOscClient(nil, remoteAddr)
+    client := osc.NewOscClient("localhost", 8765)
     msg := osc.NewOscMessage("/osc/address")
     msg.Append(int32(111))
     msg.Append(true)

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -54,11 +54,7 @@
 
    OSC client example:
 
-   remoteAddr, err := net.ResolveUDPAddr("udp", "localhost:8765")
-   if err != nil {
-      // handle err
-   }
-   client := osc.NewOscClient(nil, remoteAddr)
+   client := osc.NewOscClient("localhost", 8765)
    msg := osc.NewOscMessage("/osc/address")
    msg.Append(int32(111))
    msg.Append(true)

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -48,6 +48,7 @@ type OscBundle struct {
 type OscClient struct {
 	ipaddress string
 	port      int
+	laddr     *net.UDPAddr
 }
 
 // An OSC server. The server listens on Address and Port for incoming OSC packets
@@ -453,7 +454,7 @@ func (self *OscBundle) ToByteArray() (buffer []byte, err error) {
 // specifies the IP address and port defines the target port where the messages
 // and bundles will be send to.
 func NewOscClient(ip string, port int) (client *OscClient) {
-	return &OscClient{ipaddress: ip, port: port}
+	return &OscClient{ipaddress: ip, port: port, laddr: nil}
 }
 
 // Ip returns the IP address.
@@ -474,6 +475,17 @@ func (client *OscClient) Port() int {
 // SetPort sets a new port.
 func (client *OscClient) SetPort(port int) {
 	client.port = port
+}
+
+// SetLocalAddr sets the local address.
+func (client *OscClient) SetLocalAddr(ip string, port int) error {
+	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", ip, port))
+	if err != nil {
+		return err
+	} else {
+		client.laddr = laddr
+	}
+	return nil
 }
 
 // Send sends an OSC Bundle or an OSC Message.

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -479,9 +479,8 @@ func (client *OscClient) SetLocalAddr(ip string, port int) error {
 	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", ip, port))
 	if err != nil {
 		return err
-	} else {
-		client.laddr = laddr
 	}
+	client.laddr = laddr
 	return nil
 }
 

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -284,3 +284,15 @@ func TestServerIsNotRunningAndGetsClosed(t *testing.T) {
 		t.Errorf("Expected error if the the server is not running and it gets closed")
 	}
 }
+
+func TestClientSetLocalAddr(t *testing.T) {
+	client := NewOscClient("localhost", 8967)
+	err := client.SetLocalAddr("localhost", 41789)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	expectedAddr := "127.0.0.1:41789"
+	if client.laddr.String() != expectedAddr {
+		t.Errorf("Expected laddr to be %s but was %s", expectedAddr, client.laddr.String())
+	}
+}


### PR DESCRIPTION
I've added an `laddr` field and `SetLocalAddr` method to OscClient. This allows me to utilize the laddr parameter to net.DialUDP.