### PR TITLE
Minor API changes I found useful when implementing my Monome library

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -163,13 +163,13 @@ func (s *OscDispatcher) Dispatch(packet Packet) {
 ////
 
 // NewMessage returns a new Message. The address parameter is the OSC address.
-func NewMessage(address string) (msg *Message) {
-	return &Message{Address: address}
+func NewMessage(address string, arguments ...interface{}) (msg *Message) {
+	return &Message{Address: address, Arguments: arguments}
 }
 
 // Append appends the given argument to the arguments list.
-func (msg *Message) Append(argument interface{}) {
-	msg.Arguments = append(msg.Arguments, argument)
+func (msg *Message) Append(arguments ...interface{}) {
+	msg.Arguments = append(msg.Arguments, arguments...)
 }
 
 // Equals determines if the given OSC Message b is equal to the current OSC Message.

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -248,6 +248,41 @@ func (msg *Message) TypeTags() (tags string, err error) {
 	return tags, nil
 }
 
+func (msg *Message) String() string {
+	tags, err := msg.TypeTags()
+	if err != nil {
+		return ""
+	}
+
+	var formatString string
+	var arguments []interface{}
+	formatString += "%s %s"
+	arguments = append(arguments, msg.Address)
+	arguments = append(arguments, tags)
+
+	for _, arg := range msg.Arguments {
+		switch arg.(type) {
+		case bool, int32, int64, float32, float64, string:
+			formatString += " %v"
+			arguments = append(arguments, arg)
+
+		case nil:
+			formatString += " %s"
+			arguments = append(arguments, "Nil")
+
+		case []byte:
+			formatString += " %s"
+			arguments = append(arguments, "blob")
+
+		case Timetag:
+			formatString += " %d"
+			timeTag := arg.(Timetag)
+			arguments = append(arguments, timeTag.TimeTag())
+		}
+	}
+	return fmt.Sprintf(formatString, arguments...)
+}
+
 // CountArguments returns the number of arguments.
 func (msg *Message) CountArguments() int {
 	return len(msg.Arguments)
@@ -1010,38 +1045,7 @@ func timetagToTime(timetag uint64) (t time.Time) {
 
 // PrintMessage pretty prints an OSC message to the standard output.
 func PrintMessage(msg *Message) {
-	tags, err := msg.TypeTags()
-	if err != nil {
-		return
-	}
-
-	var formatString string
-	var arguments []interface{}
-	formatString += "%s %s"
-	arguments = append(arguments, msg.Address)
-	arguments = append(arguments, tags)
-
-	for _, arg := range msg.Arguments {
-		switch arg.(type) {
-		case bool, int32, int64, float32, float64, string:
-			formatString += " %v"
-			arguments = append(arguments, arg)
-
-		case nil:
-			formatString += " %s"
-			arguments = append(arguments, "Nil")
-
-		case []byte:
-			formatString += " %s"
-			arguments = append(arguments, "blob")
-
-		case Timetag:
-			formatString += " %d"
-			timeTag := arg.(Timetag)
-			arguments = append(arguments, timeTag.TimeTag())
-		}
-	}
-	fmt.Println(fmt.Sprintf(formatString, arguments...))
+	fmt.Println(msg.String())
 }
 
 // existsAddress returns true if the OSC address s is found in handlers. Otherwise, false.


### PR DESCRIPTION
Using variadic arguments to messages lets you construct a message object with just one line of code, eg:
`osc.NewMessage("/path", 1, 2, "hello")`

Implementing `fmt.Stringer` allows messages to be printed directly with `fmt.Println` and friends.

The ToByteArray interface was basically exactly like `BinaryMarshaler` already, so might as well use that. It allows the values to be encoded to other binary protocols (eg: gob) so the library becomes a bit more interoperable.

I think `PrintMessage` can probably be removed now.