### PR TITLE
[feature] default handler

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -97,7 +97,8 @@ func (f HandlerFunc) HandleMessage(msg *Message) {
 // OscDispatcher is a dispatcher for OSC packets. It handles the dispatching of
 // received OSC packets.
 type OscDispatcher struct {
-	handlers map[string]Handler
+	handlers       map[string]Handler
+	defaultHandler Handler
 }
 
 // NewOscDispatcher returns an OscDispatcher.
@@ -107,6 +108,10 @@ func NewOscDispatcher() (dispatcher *OscDispatcher) {
 
 // AddMsgHandler adds a new message handler for the given OSC address.
 func (s *OscDispatcher) AddMsgHandler(address string, handler HandlerFunc) error {
+	if address == "*" {
+		s.defaultHandler = handler
+		return nil
+	}
 	for _, chr := range "*?,[]{}# " {
 		if strings.Contains(address, fmt.Sprintf("%c", chr)) {
 			return errors.New("OSC Address string may not contain any characters in \"*?,[]{}# \n")
@@ -135,6 +140,9 @@ func (s *OscDispatcher) Dispatch(packet Packet) {
 				handler.HandleMessage(msg)
 			}
 		}
+		if s.defaultHandler != nil {
+			s.defaultHandler.HandleMessage(msg)
+		}
 
 	case *Bundle:
 		bundle, _ := packet.(*Bundle)
@@ -147,6 +155,9 @@ func (s *OscDispatcher) Dispatch(packet Packet) {
 					if message.Match(address) {
 						handler.HandleMessage(message)
 					}
+				}
+				if s.defaultHandler != nil {
+					s.defaultHandler.HandleMessage(message)
 				}
 			}
 


### PR DESCRIPTION
allow:
```go
server := &osc.Server{Addr: "0.0.0.0:1337"}
err := server.Handle("*", func(msg *osc.Message) {
    osc.PrintMessage(msg)
})
```
this handler match all messages address, useful for debuging purpose
