### PR TITLE
Use the default ports of TouchOSC (http://hexler.net/software/touchosc).

### DIFF
--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	addr := "127.0.0.1:8765"
+	addr := "127.0.0.1:8000"
 	server := &osc.Server{}
 	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -14,7 +14,7 @@ import (
 // TODO: Revise the client!
 func main() {
 	ip := "localhost"
-	port := 8765
+	port := 9000
 	client := osc.NewClient(ip, port)
 
 	fmt.Println("### Welcome to go-osc transmitter demo")

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -3,7 +3,7 @@ package main
 import "github.com/hypebeast/go-osc/osc"
 
 func main() {
-	addr := "127.0.0.1:8765"
+	addr := "127.0.0.1:8000"
 	server := &osc.Server{Addr: addr}
 
 	server.Handle("/message/address", func(msg *osc.Message) {


### PR DESCRIPTION
TouchOSC (http://hexler.net/software/touchosc) is a common OSC client. Use the default ports from TouchOSC (server: 8000, client: 9000) rather than 8765 in the examples.