### PR TITLE
Use Dispatcher interface in Server

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -61,7 +61,7 @@ type Client struct {
 // incoming OSC packets and bundles.
 type Server struct {
 	Addr        string
-	Dispatcher  *OscDispatcher
+	Dispatcher  Dispatcher
 	ReadTimeout time.Duration
 }
 
@@ -81,6 +81,7 @@ type Timetag struct {
 // responsible for dispatching received OSC messages.
 type Dispatcher interface {
 	Dispatch(packet Packet)
+	AddMsgHandler(addr string, f HandlerFunc) error
 }
 
 // Handler is an interface for message handlers. Every handler implementation


### PR DESCRIPTION
This PR makes `Server` use the `Dispatcher` interface, rather than using `OscDispatcher` directly.

This change allows users of this library to switch out `OscDispatcher` for other implementations as/where needed (perhaps for one which trades-off full OSC compliance for extra performance, e.g. "exact" lookups on message addresses rather than pattern lookups).

