### PR TITLE
Pull concrete dispatcher logic out of server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,17 @@ package main
 import "github.com/hypebeast/go-osc/osc"
 
 func main() {
-  addr := "127.0.0.1:8765"
-  server := &osc.Server{Addr: addr}
+    addr := "127.0.0.1:8765"
+    d := osc.NewStandardDispatcher()    
+    d.AddMsgHandler("/message/address", func(msg *osc.Message) {
+        osc.PrintMessage(msg)
+    })
 
-  server.Handle("/message/address", func(msg *osc.Message) {
-    osc.PrintMessage(msg)
-  })
-
-  server.ListenAndServe()
+    server := &osc.Server{
+        Addr: addr,
+        Dispatcher:d,
+    }
+    server.ListenAndServe()
 }
 ```
 

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -4,11 +4,15 @@ import "github.com/hypebeast/go-osc/osc"
 
 func main() {
 	addr := "127.0.0.1:8765"
-	server := &osc.Server{Addr: addr}
 
-	server.Handle("/message/address", func(msg *osc.Message) {
+	d := osc.NewStandardDispatcher()
+	d.AddMsgHandler("/message/address", func(msg *osc.Message) {
 		osc.PrintMessage(msg)
 	})
+	server := &osc.Server{
+		Addr:       addr,
+		Dispatcher: d,
+	}
 
 	server.ListenAndServe()
 }

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -61,7 +61,7 @@ type Client struct {
 // incoming OSC packets and bundles.
 type Server struct {
 	Addr        string
-	Dispatcher  *OscDispatcher
+	Dispatcher  Dispatcher
 	ReadTimeout time.Duration
 }
 
@@ -100,23 +100,23 @@ func (f HandlerFunc) HandleMessage(msg *Message) {
 }
 
 ////
-// OscDispatcher
+// StandardDispatcher
 ////
 
-// OscDispatcher is a dispatcher for OSC packets. It handles the dispatching of
-// received OSC packets.
-type OscDispatcher struct {
+// StandardDispatcher is a dispatcher for OSC packets. It handles the dispatching of
+// received OSC packets to Handlers for their given address.
+type StandardDispatcher struct {
 	handlers       map[string]Handler
 	defaultHandler Handler
 }
 
-// NewOscDispatcher returns an OscDispatcher.
-func NewOscDispatcher() *OscDispatcher {
-	return &OscDispatcher{handlers: make(map[string]Handler)}
+// NewStandardDispatcher returns an StandardDispatcher.
+func NewStandardDispatcher() *StandardDispatcher {
+	return &StandardDispatcher{handlers: make(map[string]Handler)}
 }
 
 // AddMsgHandler adds a new message handler for the given OSC address.
-func (s *OscDispatcher) AddMsgHandler(addr string, handler HandlerFunc) error {
+func (s *StandardDispatcher) AddMsgHandler(addr string, handler HandlerFunc) error {
 	if addr == "*" {
 		s.defaultHandler = handler
 		return nil
@@ -136,29 +136,27 @@ func (s *OscDispatcher) AddMsgHandler(addr string, handler HandlerFunc) error {
 }
 
 // Dispatch dispatches OSC packets. Implements the Dispatcher interface.
-func (s *OscDispatcher) Dispatch(packet Packet) {
-	switch packet.(type) {
+func (s *StandardDispatcher) Dispatch(packet Packet) {
+	switch p := packet.(type) {
 	default:
 		return
 
 	case *Message:
-		msg, _ := packet.(*Message)
 		for addr, handler := range s.handlers {
-			if msg.Match(addr) {
-				handler.HandleMessage(msg)
+			if p.Match(addr) {
+				handler.HandleMessage(p)
 			}
 		}
 		if s.defaultHandler != nil {
-			s.defaultHandler.HandleMessage(msg)
+			s.defaultHandler.HandleMessage(p)
 		}
 
 	case *Bundle:
-		bundle, _ := packet.(*Bundle)
-		timer := time.NewTimer(bundle.Timetag.ExpiresIn())
+		timer := time.NewTimer(p.Timetag.ExpiresIn())
 
 		go func() {
 			<-timer.C
-			for _, message := range bundle.Messages {
+			for _, message := range p.Messages {
 				for address, handler := range s.handlers {
 					if message.Match(address) {
 						handler.HandleMessage(message)
@@ -170,7 +168,7 @@ func (s *OscDispatcher) Dispatch(packet Packet) {
 			}
 
 			// Process all bundles
-			for _, b := range bundle.Bundles {
+			for _, b := range p.Bundles {
 				s.Dispatch(b)
 			}
 		}()
@@ -528,20 +526,11 @@ func (c *Client) Send(packet Packet) error {
 // Server
 ////
 
-// Handle registers a new message handler function for an OSC address. The
-// handler is the function called for incoming OscMessages that match 'address'.
-func (s *Server) Handle(addr string, handler HandlerFunc) error {
-	if s.Dispatcher == nil {
-		s.Dispatcher = NewOscDispatcher()
-	}
-	return s.Dispatcher.AddMsgHandler(addr, handler)
-}
-
 // ListenAndServe retrieves incoming OSC packets and dispatches the retrieved
 // OSC packets.
 func (s *Server) ListenAndServe() error {
 	if s.Dispatcher == nil {
-		s.Dispatcher = NewOscDispatcher()
+		s.Dispatcher = NewStandardDispatcher()
 	}
 
 	ln, err := net.ListenPacket("udp", s.Addr)

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -95,17 +95,17 @@ func TestMessage_String(t *testing.T) {
 	}
 }
 
-func TestHandle(t *testing.T) {
-	server := &Server{Addr: "localhost:6677"}
-	err := server.Handle("/address/test", func(msg *Message) {})
+func TestAddMsgHandler(t *testing.T) {
+	d := NewStandardDispatcher()
+	err := d.AddMsgHandler("/address/test", func(msg *Message) {})
 	if err != nil {
 		t.Error("Expected that OSC address '/address/test' is valid")
 	}
 }
 
-func TestHandleWithInvalidAddress(t *testing.T) {
-	server := &Server{Addr: "localhost:6677"}
-	err := server.Handle("/address*/test", func(msg *Message) {})
+func TestAddMsgHandlerWithInvalidAddress(t *testing.T) {
+	d := NewStandardDispatcher()
+	err := d.AddMsgHandler("/address*/test", func(msg *Message) {})
 	if err == nil {
 		t.Error("Expected error with '/address*/test'")
 	}
@@ -125,8 +125,8 @@ func TestServerMessageDispatching(t *testing.T) {
 		}
 		defer conn.Close()
 
-		server := &Server{Addr: "localhost:6677"}
-		err = server.Handle("/address/test", func(msg *Message) {
+		d := NewStandardDispatcher()
+		err = d.AddMsgHandler("/address/test", func(msg *Message) {
 			if len(msg.Arguments) != 1 {
 				t.Error("Argument length should be 1 and is: " + string(len(msg.Arguments)))
 			}
@@ -143,6 +143,7 @@ func TestServerMessageDispatching(t *testing.T) {
 			t.Error("Error adding message handler")
 		}
 
+		server := &Server{Addr: "localhost:6677", Dispatcher: d}
 		start <- true
 		server.Serve(conn)
 	}()


### PR DESCRIPTION
This allows the use of custom Dispatchers, making the Server more flexible.

Previously, the `*` handler could be used but this would still mean that the logic of the OscDispatcher would have to be gone through before being routed to the defaultHandler.