### PR TITLE
Allow nil type tags on server, clean up net connection on failure

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -774,6 +774,9 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			*start += 8
 			msg.Append(NewTimetagFromTimetag(tt))
 
+		case 'N': // nil
+			msg.Append(nil)
+
 		case 'T': // true
 			msg.Append(true)
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -537,6 +537,8 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
+	defer ln.Close()
+
 	return s.Serve(ln)
 }
 


### PR DESCRIPTION
This PR incorporates two changes, handling nil type tags on an osc server, and closing the udp connection when `ListenAndServe` crashes.

The first change fixes a crash I encountered. The second fixes the issue I discovered when I attempted to adjust my code to re-open the port after such a crash and was unable to do so, as the port was already in use.