### PR TITLE
TCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ## Features
 
+* UDP (default) or TCP
 * OSC Bundles, including timetags
 * OSC Messages
 * OSC Client

--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -101,8 +101,9 @@ func main() {
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
-	server := osc.NewServer(addr, Debugger{}, 0)
-	server.SetNetworkProtocol(protocol)
+	server := osc.NewServer(addr, Debugger{}, 0,
+		// defaults to UDP if not used
+		osc.WithProtocol(protocol))
 
 	fmt.Println("### Welcome to go-osc receiver demo")
 	fmt.Printf("Listening via %s on port %d...\n", protocol, port)

--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -34,7 +34,7 @@ func main() {
 			if packet != nil {
 				switch packet.(type) {
 				default:
-					fmt.Println("Unknow packet type!")
+					fmt.Println("Unknown packet type!")
 
 				case *osc.Message:
 					fmt.Printf("-- OSC Message: ")

--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -103,7 +103,7 @@ func main() {
 
 	server := osc.NewServer(addr, Debugger{}, 0,
 		// defaults to UDP if not used
-		osc.WithProtocol(protocol))
+		osc.ServerProtocol(protocol))
 
 	fmt.Println("### Welcome to go-osc receiver demo")
 	fmt.Printf("Listening via %s on port %d...\n", protocol, port)

--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -1,67 +1,114 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"net"
+	"math/rand"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/hypebeast/go-osc/osc"
 )
 
-func main() {
-	addr := "127.0.0.1:8765"
-	server := &osc.Server{}
-	conn, err := net.ListenPacket("udp", addr)
-	if err != nil {
-		fmt.Println("Couldn't listen: ", err)
+func indent(str string, indentLevel int) string {
+	indentation := strings.Repeat("  ", indentLevel)
+
+	result := ""
+
+	for i, line := range strings.Split(str, "\n") {
+		if i != 0 {
+			result += "\n"
+		}
+
+		result += indentation + line
 	}
-	defer conn.Close()
+
+	return result
+}
+
+func debug(packet osc.Packet, indentLevel int) string {
+	switch packet.(type) {
+	default:
+		return "Unknown packet type!"
+
+	case *osc.Message:
+		return fmt.Sprintf("-- OSC Message: %s", packet.(*osc.Message))
+
+	case *osc.Bundle:
+		bundle := packet.(*osc.Bundle)
+
+		result := fmt.Sprintf("-- OSC Bundle (%s):", bundle.Timetag.Time())
+
+		for i, message := range bundle.Messages {
+			result += "\n" + indent(
+				fmt.Sprintf("-- OSC Message #%d: %s", i+1, message),
+				indentLevel+1,
+			)
+		}
+
+		for _, bundle := range bundle.Bundles {
+			result += "\n" + indent(debug(bundle, 0), indentLevel+1)
+		}
+
+		return result
+	}
+}
+
+// Debugger is a simple Dispatcher that prints all messages and bundles as they
+// are received.
+type Debugger struct{}
+
+// Dispatch implements Dispatcher.Dispatch by printing the packet received.
+func (Debugger) Dispatch(packet osc.Packet) {
+	if packet != nil {
+		fmt.Println(debug(packet, 0) + "\n")
+	}
+}
+
+func printUsage() {
+	fmt.Printf("Usage: %s PROTOCOL PORT\n", os.Args[0])
+}
+
+func main() {
+	rand.Seed(time.Now().Unix())
+
+	numArgs := len(os.Args[1:])
+
+	if numArgs != 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	var protocol osc.NetworkProtocol
+	switch strings.ToLower(os.Args[1]) {
+	case "udp":
+		protocol = osc.UDP
+	case "tcp":
+		protocol = osc.TCP
+	default:
+		fmt.Println("Invalid protocol: " + os.Args[1])
+		printUsage()
+		os.Exit(1)
+	}
+
+	port, err := strconv.ParseInt(os.Args[2], 10, 32)
+	if err != nil {
+		fmt.Println(err)
+		printUsage()
+		os.Exit(1)
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	server := osc.NewServer(addr, Debugger{}, 0)
+	server.SetNetworkProtocol(protocol)
 
 	fmt.Println("### Welcome to go-osc receiver demo")
-	fmt.Println("Press \"q\" to exit")
+	fmt.Printf("Listening via %s on port %d...\n", protocol, port)
 
-	go func() {
-		fmt.Println("Start listening on", addr)
-
-		for {
-			packet, err := server.ReceivePacket(conn)
-			if err != nil {
-				fmt.Println("Server error: " + err.Error())
-				os.Exit(1)
-			}
-
-			if packet != nil {
-				switch packet.(type) {
-				default:
-					fmt.Println("Unknown packet type!")
-
-				case *osc.Message:
-					fmt.Printf("-- OSC Message: ")
-					osc.PrintMessage(packet.(*osc.Message))
-
-				case *osc.Bundle:
-					fmt.Println("-- OSC Bundle:")
-					bundle := packet.(*osc.Bundle)
-					for i, message := range bundle.Messages {
-						fmt.Printf("  -- OSC Message #%d: ", i+1)
-						osc.PrintMessage(message)
-					}
-				}
-			}
-		}
-	}()
-
-	reader := bufio.NewReader(os.Stdin)
-
-	for {
-		c, err := reader.ReadByte()
-		if err != nil {
-			os.Exit(0)
-		}
-
-		if c == 'q' {
-			os.Exit(0)
-		}
+	if err := server.ListenAndServe(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -4,18 +4,110 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hypebeast/go-osc/osc"
 )
 
-// TODO: Revise the client!
+func testString() string {
+	return "test string " + strconv.Itoa(rand.Intn(1000))
+}
+
+func testBlob() []byte {
+	return []byte(testString())
+}
+
+var argFunctions = []func(*osc.Message){
+	func(msg *osc.Message) {
+		msg.Append(int32(rand.Intn(100000)))
+	},
+	func(msg *osc.Message) {
+		msg.Append(rand.Float32() * 100000)
+	},
+	func(msg *osc.Message) {
+		msg.Append(testString())
+	},
+	func(msg *osc.Message) {
+		msg.Append(testBlob())
+	},
+	func(msg *osc.Message) {
+		msg.Append(*osc.NewTimetag(time.Now()))
+	},
+	func(msg *osc.Message) {
+		msg.Append(true)
+	},
+	func(msg *osc.Message) {
+		msg.Append(false)
+	},
+	func(msg *osc.Message) {
+		msg.Append(nil)
+	},
+}
+
+func randomMessage(address string) *osc.Message {
+	message := osc.NewMessage(address)
+
+	for i := 0; i < 1+rand.Intn(5); i++ {
+		argFunctions[rand.Intn(len(argFunctions))](message)
+	}
+
+	return message
+}
+
+func randomBundle() *osc.Bundle {
+	bundle := osc.NewBundle(time.Now())
+
+	for i := 0; i < 1+rand.Intn(5); i++ {
+		if rand.Float32() < 0.25 {
+			bundle.Append(randomBundle())
+		} else {
+			bundle.Append(randomMessage("/bundle/message/" + strconv.Itoa(i+1)))
+		}
+	}
+
+	return bundle
+}
+
+func printUsage() {
+	fmt.Printf("Usage: %s PROTOCOL PORT\n", os.Args[0])
+}
+
 func main() {
+	rand.Seed(time.Now().Unix())
+
+	numArgs := len(os.Args[1:])
+
+	if numArgs != 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	var protocol osc.NetworkProtocol
+	switch strings.ToLower(os.Args[1]) {
+	case "udp":
+		protocol = osc.UDP
+	case "tcp":
+		protocol = osc.TCP
+	default:
+		fmt.Println("Invalid protocol: " + os.Args[1])
+		printUsage()
+		os.Exit(1)
+	}
+
+	port, err := strconv.ParseInt(os.Args[2], 10, 32)
+	if err != nil {
+		fmt.Println(err)
+		printUsage()
+		os.Exit(1)
+	}
+
 	ip := "localhost"
-	port := 8765
-	client := osc.NewClient(ip, port)
+	client := osc.NewClient(ip, int(port))
+	client.SetNetworkProtocol(protocol)
 
 	fmt.Println("### Welcome to go-osc transmitter demo")
 	fmt.Println("Please, select the OSC packet type you would like to send:")
@@ -38,28 +130,13 @@ func main() {
 
 		sline := strings.TrimRight(string(line), "\n")
 		if sline == "m" {
-			message := osc.NewMessage("/message/address")
-			message.Append(int32(12345))
-			message.Append("teststring")
-			message.Append(true)
-			message.Append(false)
-			client.Send(message)
+			if err := client.Send(randomMessage("/message/address")); err != nil {
+				fmt.Println(err)
+			}
 		} else if sline == "b" {
-			bundle := osc.NewBundle(time.Now())
-			message1 := osc.NewMessage("/bundle/message/1")
-			message1.Append(int32(12345))
-			message1.Append("teststring")
-			message1.Append(true)
-			message1.Append(false)
-			message2 := osc.NewMessage("/bundle/message/2")
-			message2.Append(int32(3344))
-			message2.Append(float32(101.9))
-			message2.Append("string1")
-			message2.Append("string2")
-			message2.Append(true)
-			bundle.Append(message1)
-			bundle.Append(message2)
-			client.Send(bundle)
+			if err := client.Send(randomBundle()); err != nil {
+				fmt.Println(err)
+			}
 		} else if sline == "q" {
 			fmt.Println("Exit!")
 			os.Exit(0)

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -106,8 +106,7 @@ func main() {
 	}
 
 	ip := "localhost"
-	client := osc.NewClient(ip, int(port))
-	client.SetNetworkProtocol(protocol)
+	client := osc.NewClient(ip, int(port), osc.ClientProtocol(protocol))
 
 	fmt.Println("### Welcome to go-osc transmitter demo")
 	fmt.Println("Please, select the OSC packet type you would like to send:")

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -1,18 +1,67 @@
 package main
 
-import "github.com/hypebeast/go-osc/osc"
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hypebeast/go-osc/osc"
+)
+
+func printUsage() {
+	fmt.Printf("Usage: %s PROTOCOL PORT\n", os.Args[0])
+}
 
 func main() {
-	addr := "127.0.0.1:8765"
+	rand.Seed(time.Now().Unix())
 
-	d := osc.NewStandardDispatcher()
-	d.AddMsgHandler("/message/address", func(msg *osc.Message) {
-		osc.PrintMessage(msg)
-	})
-	server := &osc.Server{
-		Addr:       addr,
-		Dispatcher: d,
+	numArgs := len(os.Args[1:])
+
+	if numArgs != 2 {
+		printUsage()
+		os.Exit(1)
 	}
 
-	server.ListenAndServe()
+	var protocol osc.NetworkProtocol
+	switch strings.ToLower(os.Args[1]) {
+	case "udp":
+		protocol = osc.UDP
+	case "tcp":
+		protocol = osc.TCP
+	default:
+		fmt.Println("Invalid protocol: " + os.Args[1])
+		printUsage()
+		os.Exit(1)
+	}
+
+	port, err := strconv.ParseInt(os.Args[2], 10, 32)
+	if err != nil {
+		fmt.Println(err)
+		printUsage()
+		os.Exit(1)
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	d := osc.NewStandardDispatcher()
+
+	if err := d.AddMsgHandler("/message/address", func(msg *osc.Message) {
+		osc.PrintMessage(msg)
+	}); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	server := osc.NewServer(addr, d, 0)
+	server.SetNetworkProtocol(protocol)
+
+	fmt.Printf("Listening via %s on port %d...\n", protocol, port)
+
+	if err := server.ListenAndServe(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -55,8 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	server := osc.NewServer(addr, d, 0,
-		osc.WithProtocol(protocol))
+	server := osc.NewServer(addr, d, 0, osc.ServerProtocol(protocol))
 
 	fmt.Printf("Listening via %s on port %d...\n", protocol, port)
 

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -55,8 +55,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	server := osc.NewServer(addr, d, 0)
-	server.SetNetworkProtocol(protocol)
+	server := osc.NewServer(addr, d, 0,
+		osc.WithProtocol(protocol))
 
 	fmt.Printf("Listening via %s on port %d...\n", protocol, port)
 

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -74,13 +74,10 @@ OSC server example:
         osc.PrintMessage(msg)
     })
 
-    server := &osc.Server{
-        Addr: addr,
-        Dispatcher:d,
-    }
-
+		server := osc.NewServer(addr, d, 0)
     // To use TCP instead of UDP:
-    // osc.WithProtocol(osc.TCP)
+    // server := osc.NewServer(addr, d, 0, osc.ServerProtocol(osc.TCP))
+
     server.ListenAndServe()
 */
 package osc

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -80,8 +80,7 @@ OSC server example:
     }
 
     // To use TCP instead of UDP:
-    // server.SetNetworkProtocol(osc.TCP)
-
+    // server.WithProtocol(osc.TCP)
     server.ListenAndServe()
 */
 package osc

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -80,7 +80,7 @@ OSC server example:
     }
 
     // To use TCP instead of UDP:
-    // server.WithProtocol(osc.TCP)
+    // osc.WithProtocol(osc.TCP)
     server.ListenAndServe()
 */
 package osc

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -59,7 +59,7 @@ OSC client example:
 
     client := osc.NewClient("localhost", 8765)
     // To use TCP instead of UDP:
-    // client.SetNetworkProtocol(osc.TCP)
+    // client := osc.NewClient("localhost", 8765, osc.ClientProtocol(osc.TCP))
     msg := osc.NewMessage("/osc/address")
     msg.Append(int32(111))
     msg.Append(true)

--- a/osc/doc.go
+++ b/osc/doc.go
@@ -21,8 +21,8 @@ Features:
 - Support for OSC address pattern including '*', '?', '{,}' and '[]' wildcards
 - TODO: Describe registering methods
 
-This OSC implementation uses the UDP protocol for sending and receiving
-OSC packets.
+This OSC implementation supports using UDP or TCP as the protocol for sending
+and receiving OSC packets. UDP is used by default.
 
 The unit of transmission of OSC is an OSC Packet. Any application that sends
 OSC Packets is an OSC Client; any application that receives OSC Packets is
@@ -59,6 +59,8 @@ Usage
 OSC client example:
 
    client := osc.NewClient("localhost", 8765)
+	 // To use TCP instead of UDP:
+	 // client.SetNetworkProtocol(osc.TCP)
    msg := osc.NewMessage("/osc/address")
    msg.Append(int32(111))
    msg.Append(true)
@@ -68,7 +70,9 @@ OSC client example:
 OSC server example:
 
    addr := "127.0.0.1:8765"
-   server := &osc.Server{Addr: addr}
+   server := osc.Server{Addr: addr}
+	 // To use TCP instead of UDP:
+	 // server.SetNetworkProtocol(osc.TCP)
 
    server.Handle("/message/address", func(msg *osc.Message) {
       osc.PrintMessage(msg)

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -954,6 +954,7 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 
 		case 'F': // false
 			msg.Append(false)
+		}
 	}
 
 	return nil

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -633,11 +633,24 @@ func (s *Server) ListenAndServe() error {
 		s.Dispatcher = NewOscDispatcher()
 	}
 
-	ln, err := net.ListenPacket("udp", s.Addr)
-	if err != nil {
-		return err
+	switch s.networkProtocol {
+	case UDP:
+		ln, err := net.ListenPacket("udp", s.Addr)
+		if err != nil {
+			return err
+		}
+
+		return s.Serve(ln)
+	case TCP:
+		l, err := net.Listen("tcp", s.Addr)
+		if err != nil {
+			return err
+		}
+
+		return s.ServeTCP(l)
+	default:
+		return fmt.Errorf("unsupported network protocol: %v", s.networkProtocol)
 	}
-	return s.Serve(ln)
 }
 
 func (s *Server) serve(readPacket func() (Packet, error)) error {

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -622,9 +622,13 @@ func (s *Server) Handle(addr string, handler HandlerFunc) error {
 	return s.Dispatcher.AddMsgHandler(addr, handler)
 }
 
-// ListenAndServe retrieves incoming OSC packets and dispatches the retrieved
-// OSC packets.
+// ListenAndServe opens a connection, retrieves incoming OSC packets and
+// dispatches the retrieved OSC packets.
+//
+// The connection is closed in the event of an error or interruption.
 func (s *Server) ListenAndServe() error {
+	defer s.CloseConnection()
+
 	if s.Dispatcher == nil {
 		s.Dispatcher = NewOscDispatcher()
 	}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -664,6 +664,10 @@ func (s *Server) ListenAndServe() error {
 	}
 }
 
+// Serve uses the provided ReceiveFunc to retrieve and dispatch incoming OSC
+// packets in a loop.
+//
+// Returns an error if something goes awry.
 func (s *Server) Serve(readPacket ReceiveFunc) error {
 	var tempDelay time.Duration
 	for {

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -686,9 +686,13 @@ func (s *Server) ServeTCP(l net.Listener) error {
 func (s *Server) CloseConnection() {
 	switch s.networkProtocol {
 	case UDP:
-		s.udpConnection.Close()
+		if s.udpConnection != nil {
+			s.udpConnection.Close()
+		}
 	case TCP:
-		s.tcpListener.Close()
+		if s.tcpListener != nil {
+			s.tcpListener.Close()
+		}
 	}
 }
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -602,8 +602,8 @@ type ServerOption func(*Server)
 // NewServer creates a new OSC server. The server receives OSC messages and
 // bundles over a network connection.
 //
-// The default network protocol is UDP. To use TCP instead, use
-// osc.WithProtocol(TCP).
+// The default network protocol is UDP. To use TCP instead, use the ServerOption
+// osc.ServerProtocol(TCP).
 func NewServer(
 	addr string, dispatcher Dispatcher, readTimeout time.Duration,
 	opts ...ServerOption,
@@ -624,8 +624,8 @@ func (s *Server) NetworkProtocol() NetworkProtocol {
 	return s.networkProtocol
 }
 
-// WithProtocol sets the network protocol.
-func WithProtocol(protocol NetworkProtocol) ServerOption {
+// ServerProtocol sets the network protocol.
+func ServerProtocol(protocol NetworkProtocol) ServerOption {
 	return func(server *Server) {
 		server.networkProtocol = protocol
 	}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,6 +33,17 @@ const (
 	// TCP represents the TCP network protocol.
 	TCP
 )
+
+func (protocol NetworkProtocol) String() string {
+	switch protocol {
+	case UDP:
+		return "UDP"
+	case TCP:
+		return "TCP"
+	default:
+		return strconv.Itoa(int(protocol))
+	}
+}
 
 // Packet is the interface for Message and Bundle.
 type Packet interface {

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -72,9 +72,10 @@ type Client struct {
 // Server represents an OSC server. The server listens on Address and Port for
 // incoming OSC packets and bundles.
 type Server struct {
-	Addr        string
-	Dispatcher  *OscDispatcher
-	ReadTimeout time.Duration
+	Addr            string
+	Dispatcher      *OscDispatcher
+	ReadTimeout     time.Duration
+	networkProtocol NetworkProtocol
 }
 
 // Timetag represents an OSC Time Tag.
@@ -549,6 +550,31 @@ func (c *Client) Send(packet Packet) error {
 ////
 // Server
 ////
+
+// NewServer creates a new OSC client. The Server is used to send OSC
+// messages and OSC bundles over an UDP network connection. The `ip` argument
+// specifies the IP address and `port` defines the target port where the
+// messages and bundles will be send to.
+func NewServer(
+	addr string, dispatcher *OscDispatcher, readTimeout time.Duration,
+) *Server {
+	return &Server{
+		Addr:            addr,
+		Dispatcher:      dispatcher,
+		ReadTimeout:     readTimeout,
+		networkProtocol: UDP,
+	}
+}
+
+// NetworkProtocol returns the network protocol.
+func (s *Server) NetworkProtocol() NetworkProtocol {
+	return s.networkProtocol
+}
+
+// SetNetworkProtocol sets the network protocol.
+func (s *Server) SetNetworkProtocol(protocol NetworkProtocol) {
+	s.networkProtocol = protocol
+}
 
 // Handle registers a new message handler function for an OSC address. The
 // handler is the function called for incoming OscMessages that match 'address'.

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -835,6 +835,10 @@ func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
 		}
 		*start += 4
 
+		if length == 0 {
+			continue
+		}
+
 		p, err := readPacket(reader, start, end)
 		if err != nil {
 			return nil, err

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -691,12 +691,12 @@ func (s *Server) Serve(readPacket ReceiveFunc) error {
 //
 // This causes a "use of closed network connection" error the next time the
 // server attempts to read from the connection.
-// TODO(glynternet): return error here
-func (s *Server) CloseConnection() {
+func (s *Server) CloseConnection() error {
 	if s.close == nil {
-		return
+		return nil
 	}
-	s.close()
+
+	return s.close()
 }
 
 // ReceivePacket listens for incoming OSC packets and returns the packet if one is received.

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -603,7 +603,7 @@ type ServerOption func(*Server)
 // bundles over a network connection.
 //
 // The default network protocol is UDP. To use TCP instead, use the ServerOption
-// osc.ServerProtocol(TCP).
+// ServerProtocol(TCP).
 func NewServer(
 	addr string, dispatcher Dispatcher, readTimeout time.Duration,
 	opts ...ServerOption,

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -835,10 +835,6 @@ func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
 		}
 		*start += 4
 
-		if length == 0 {
-			continue
-		}
-
 		p, err := readPacket(reader, start, end)
 		if err != nil {
 			return nil, err

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -486,9 +486,13 @@ func (b *Bundle) MarshalBinary() ([]byte, error) {
 ////
 
 // NewClient creates a new OSC client. The Client is used to send OSC
-// messages and OSC bundles over an UDP network connection. The `ip` argument
-// specifies the IP address and `port` defines the target port where the
-// messages and bundles will be send to.
+// messages and OSC bundles over a network connection.
+//
+// The default network protocol is UDP. To use TCP instead, use
+// client.SetNetworkProtocol(TCP).
+//
+// The `ip` argument specifies the IP address and `port` defines the target port
+// where the messages and bundles will be send to.
 func NewClient(ip string, port int) *Client {
 	return &Client{ip: ip, port: port, laddr: nil, networkProtocol: UDP}
 }
@@ -552,10 +556,11 @@ func (c *Client) Send(packet Packet) error {
 // Server
 ////
 
-// NewServer creates a new OSC client. The Server is used to send OSC
-// messages and OSC bundles over an UDP network connection. The `ip` argument
-// specifies the IP address and `port` defines the target port where the
-// messages and bundles will be send to.
+// NewServer creates a new OSC server. The server receives OSC messages and
+// bundles over a network connection.
+//
+// The default network protocol is UDP. To use TCP instead, use
+// server.SetNetworkProtocol(TCP).
 func NewServer(
 	addr string, dispatcher *OscDispatcher, readTimeout time.Duration,
 ) *Server {

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"reflect"
 	"regexp"
@@ -666,14 +667,14 @@ func (s *Server) ReceiveTCPPacket(l net.Listener) (Packet, error) {
 		}
 	}
 
-	data := make([]byte, 65535)
-	n, err := conn.Read(data)
+	data, err := ioutil.ReadAll(conn)
 	if err != nil {
 		return nil, err
 	}
 
 	var start int
-	p, err := readPacket(bufio.NewReader(bytes.NewBuffer(data)), &start, n)
+	end := len(data)
+	p, err := readPacket(bufio.NewReader(bytes.NewBuffer(data)), &start, end)
 	if err != nil {
 		return nil, err
 	}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -294,9 +294,9 @@ func (msg *Message) String() string {
 			formatString += " %s"
 			args = append(args, "blob")
 
-		case Timetag:
+		case *Timetag:
 			formatString += " %d"
-			timeTag := arg.(Timetag)
+			timeTag := arg.(*Timetag)
 			args = append(args, timeTag.TimeTag())
 		}
 	}
@@ -1233,7 +1233,7 @@ func getTypeTag(arg interface{}) (string, error) {
 		return "h", nil
 	case float64:
 		return "d", nil
-	case Timetag:
+	case *Timetag:
 		return "t", nil
 	default:
 		return "", fmt.Errorf("Unsupported type: %T", t)

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -603,7 +603,7 @@ type ServerOption func(*Server)
 // bundles over a network connection.
 //
 // The default network protocol is UDP. To use TCP instead, use
-// server.WithProtocol(TCP).
+// osc.WithProtocol(TCP).
 func NewServer(
 	addr string, dispatcher Dispatcher, readTimeout time.Duration,
 	opts ...ServerOption,

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -67,6 +67,7 @@ type Client struct {
 	ip              string
 	port            int
 	laddr           *net.UDPAddr
+	laddrTCP        *net.TCPAddr
 	networkProtocol NetworkProtocol
 }
 
@@ -511,11 +512,21 @@ func (c *Client) SetPort(port int) { c.port = port }
 
 // SetLocalAddr sets the local address.
 func (c *Client) SetLocalAddr(ip string, port int) error {
-	laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", ip, port))
-	if err != nil {
-		return err
+	switch c.networkProtocol {
+	case UDP:
+		laddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", ip, port))
+		if err != nil {
+			return err
+		}
+		c.laddr = laddr
+	case TCP:
+		laddrTCP, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", ip, port))
+		if err != nil {
+			return err
+		}
+		c.laddrTCP = laddrTCP
 	}
-	c.laddr = laddr
+
 	return nil
 }
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -21,6 +21,17 @@ const (
 	bundleTagString       = "#bundle"
 )
 
+// NetworkProtocol represents a network protocol that can be used to transport
+// OSC messages.
+type NetworkProtocol int
+
+const (
+	// UDP represents the UDP network protocol.
+	UDP NetworkProtocol = iota
+	// TCP represents the TCP network protocol.
+	TCP
+)
+
 // Packet is the interface for Message and Bundle.
 type Packet interface {
 	encoding.BinaryMarshaler
@@ -52,9 +63,10 @@ var _ Packet = (*Bundle)(nil)
 // Client enables you to send OSC packets. It sends OSC messages and bundles to
 // the given IP address and port.
 type Client struct {
-	ip    string
-	port  int
-	laddr *net.UDPAddr
+	ip              string
+	port            int
+	laddr           *net.UDPAddr
+	networkProtocol NetworkProtocol
 }
 
 // Server represents an OSC server. The server listens on Address and Port for
@@ -476,7 +488,7 @@ func (b *Bundle) MarshalBinary() ([]byte, error) {
 // specifies the IP address and `port` defines the target port where the
 // messages and bundles will be send to.
 func NewClient(ip string, port int) *Client {
-	return &Client{ip: ip, port: port, laddr: nil}
+	return &Client{ip: ip, port: port, laddr: nil, networkProtocol: UDP}
 }
 
 // IP returns the IP address.
@@ -499,6 +511,16 @@ func (c *Client) SetLocalAddr(ip string, port int) error {
 	}
 	c.laddr = laddr
 	return nil
+}
+
+// NetworkProtocol returns the network protocol.
+func (c *Client) NetworkProtocol() NetworkProtocol {
+	return c.networkProtocol
+}
+
+// SetNetworkProtocol sets the network protocol.
+func (c *Client) SetNetworkProtocol(protocol NetworkProtocol) {
+	c.networkProtocol = protocol
 }
 
 // Send sends an OSC Bundle or an OSC Message.

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -596,7 +596,8 @@ func (c *Client) Send(packet Packet) error {
 // Server
 ////
 
-type Option func(*Server)
+// ServerOption is a function that customizes a Server instance.
+type ServerOption func(*Server)
 
 // NewServer creates a new OSC server. The server receives OSC messages and
 // bundles over a network connection.
@@ -605,7 +606,7 @@ type Option func(*Server)
 // server.WithProtocol(TCP).
 func NewServer(
 	addr string, dispatcher Dispatcher, readTimeout time.Duration,
-	opts ...Option,
+	opts ...ServerOption,
 ) *Server {
 	srv := &Server{
 		Addr:        addr,
@@ -624,7 +625,7 @@ func (s *Server) NetworkProtocol() NetworkProtocol {
 }
 
 // WithProtocol sets the network protocol.
-func WithProtocol(protocol NetworkProtocol) Option {
+func WithProtocol(protocol NetworkProtocol) ServerOption {
 	return func(server *Server) {
 		server.networkProtocol = protocol
 	}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -951,6 +951,9 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 
 		case 'F': // false
 			msg.Append(false)
+
+		case 'N': // null
+			msg.Append(nil)
 		}
 	}
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -542,24 +542,42 @@ func (c *Client) SetNetworkProtocol(protocol NetworkProtocol) {
 
 // Send sends an OSC Bundle or an OSC Message.
 func (c *Client) Send(packet Packet) error {
-	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", c.ip, c.port))
-	if err != nil {
-		return err
-	}
-	conn, err := net.DialUDP("udp", c.laddr, addr)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	data, err := packet.MarshalBinary()
 	if err != nil {
 		return err
 	}
 
-	if _, err = conn.Write(data); err != nil {
-		return err
+	switch c.networkProtocol {
+	case UDP:
+		addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", c.ip, c.port))
+		if err != nil {
+			return err
+		}
+		conn, err := net.DialUDP("udp", c.laddr, addr)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		if _, err = conn.Write(data); err != nil {
+			return err
+		}
+	case TCP:
+		addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", c.ip, c.port))
+		if err != nil {
+			return err
+		}
+		conn, err := net.DialTCP("tcp", c.laddrTCP, addr)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		if _, err = conn.Write(data); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -312,7 +312,7 @@ func TestServerMessageReceivingUDP(t *testing.T) {
 }
 
 func TestServerMessageReceivingTCP(t *testing.T) {
-	testServerMessageReceiving(t, TCP, randomString(100000))
+	testServerMessageReceiving(t, TCP, randomString(1000000))
 }
 
 func TestReadTimeout(t *testing.T) {

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -255,7 +255,12 @@ func testServerMessageReceiving(
 			msg.Append(int32(3344))
 			msg.Append(stringArgument)
 			time.Sleep(500 * time.Millisecond)
-			client.Send(msg)
+			if err := client.Send(msg); err != nil {
+				t.Error(err)
+				done.Done()
+				done.Done()
+				return
+			}
 		}
 
 		done.Done()

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -142,7 +142,9 @@ func testServerMessageDispatching(
 	port := 6677
 	addr := "localhost:" + strconv.Itoa(port)
 
-	server := NewServer(addr, NewStandardDispatcher(), 0, WithProtocol(protocol))
+	server := NewServer(
+		addr, NewStandardDispatcher(), 0, ServerProtocol(protocol),
+	)
 	defer server.CloseConnection()
 
 	if err := server.Dispatcher.(*StandardDispatcher).AddMsgHandler(

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -257,7 +257,7 @@ func testServerMessageReceiving(
 		select {
 		case <-timeout:
 		case <-start:
-			client := NewClient("localhost", 6677)
+			client := NewClient("localhost", port)
 			client.SetNetworkProtocol(protocol)
 
 			msg := NewMessage("/address/test")

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -298,6 +298,16 @@ func randomString(length int) string {
 }
 
 func TestServerMessageReceivingUDP(t *testing.T) {
+	// Attempting to send a message larger than this (the exact threshold depends
+	// on your OS, etc.) results in an error like:
+	//
+	//   write udp 127.0.0.1:52496->127.0.0.1:6677: write: message too long
+	//
+	// This is expected for UDP. The practical guaranteed packet size limit for
+	// UDP is 576 bytes, and some of that is taken up by protocol overhead.
+	//
+	// Reference:
+	// https://forum.juce.com/t/osc-blobs-are-lost-above-certain-size/20241/2
 	testServerMessageReceiving(t, UDP, randomString(500))
 }
 

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -195,8 +195,7 @@ func testServerMessageDispatching(
 		case <-timeout:
 		case <-start:
 			time.Sleep(500 * time.Millisecond)
-			client := NewClient("localhost", port)
-			client.SetNetworkProtocol(protocol)
+			client := NewClient("localhost", port, ClientProtocol(protocol))
 			msg := NewMessage("/address/test")
 			msg.Append(int32(1122))
 			msg.Append(stringArgument)
@@ -321,8 +320,7 @@ func testServerMessageReceiving(
 		select {
 		case <-timeout:
 		case <-start:
-			client := NewClient("localhost", port)
-			client.SetNetworkProtocol(protocol)
+			client := NewClient("localhost", port, ClientProtocol(protocol))
 
 			msg := NewMessage("/address/test")
 			msg.Append(int32(1122))
@@ -548,8 +546,9 @@ func TestClientSetLocalAddr(t *testing.T) {
 		t.Error(err.Error())
 	}
 	expectedAddr := "127.0.0.1:41789"
-	if client.laddr.String() != expectedAddr {
-		t.Errorf("Expected laddr to be %s but was %s", expectedAddr, client.laddr.String())
+	actualAddr := client.LocalAddrString()
+	if actualAddr != expectedAddr {
+		t.Errorf("Expected laddr to be %s but was %s", expectedAddr, actualAddr)
 	}
 }
 

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -235,8 +235,18 @@ func testServerMessageReceiving(
 		if msg.Arguments[1].(int32) != 3344 {
 			t.Error("Argument should be 3344 and is: " + string(msg.Arguments[1].(int32)))
 		}
-		if msg.Arguments[2].(string) != stringArgument {
-			t.Errorf("Argument should be %s and is: " + msg.Arguments[2].(string))
+
+		receivedString := msg.Arguments[2].(string)
+		if len(receivedString) != len(stringArgument) {
+			t.Errorf(
+				"String argument length should be %d and is %d",
+				len(stringArgument),
+				len(receivedString),
+			)
+		} else if receivedString != stringArgument {
+			t.Errorf(
+				"Argument should be %s and is: %s", stringArgument, receivedString,
+			)
 		}
 
 		finish <- true

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -138,7 +138,7 @@ func testServerMessageDispatching(t *testing.T, protocol NetworkProtocol) {
 			startServer = func() error {
 				c, err := net.ListenPacket("udp", addr)
 				if err != nil {
-					t.Fatal(err)
+					return err
 				}
 
 				stopServer = func() { c.Close() }
@@ -239,7 +239,7 @@ func testServerMessageReceiving(
 			receivePacket = func() (Packet, error) {
 				c, err := net.ListenPacket("udp", "localhost:"+strconv.Itoa(port))
 				if err != nil {
-					t.Fatal(err)
+					return nil, err
 				}
 				defer c.Close()
 
@@ -249,7 +249,7 @@ func testServerMessageReceiving(
 			receivePacket = func() (Packet, error) {
 				l, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 				if err != nil {
-					t.Fatal(err)
+					return nil, err
 				}
 				defer l.Close()
 


### PR DESCRIPTION
This implements TCP support in the way I described in #34.

Brief summary:

* I've done this in a backwards-compatible way, with UDP as the default network protocol.
* To use TCP, call `client.SetNetworkProtocol(osc.TCP)` or `server.SetNetworkProtocol(osc.TCP)`.
* Incidental: I added a `server.CloseConnection` function to facilitate testing and give users the ability to forcibly stop a running server.
  * `ListenAndServe` includes `defer server.CloseConnection()`, ensuring that the connection it creates is closed in the event of an interruption or error.

I also made some adjustments and improvements to the tests and examples. I did some thorough testing involving this branch of go-osc and a similar branch of [JavaOSC](https://github.com/hoijui/JavaOSC) where I've just finished implementing TCP support. I tested all the permutations of TCP vs. UDP, Go client vs. Java client, Go server vs. Java server, and everything is looking great, as far as I can tell.

Feedback welcome, of course. I realize this is a big change set! Let me know if there's anything I can do to make reviewing it easier.

Thanks for all the excellent work on go-osc!