### PR TITLE
Add a random string argument to message dispatch/receive tests

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -581,7 +581,16 @@ func (s *Server) CloseConnection() error {
 		return nil
 	}
 
-	return s.close()
+	err := s.close()
+	// If we get "use of closed network connection", it's not a problem because
+	// closing the network connection is exactly what we wanted to do!
+	if err != nil && !strings.Contains(
+		err.Error(), "use of closed network connection",
+	) {
+		return err
+	}
+
+	return nil
 }
 
 // ReceivePacket listens for incoming OSC packets and returns the packet if one is received.

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -159,7 +159,7 @@ func testServerMessageDispatching(t *testing.T, stringArgument string) {
 			}()
 
 			if len(msg.Arguments) != 2 {
-				t.Errorf("Argument length should be 2 and is: %d ", len(msg.Arguments))
+				t.Errorf("Argument length should be 2 and is: %d", len(msg.Arguments))
 			}
 
 			if msg.Arguments[0].(int32) != 1122 {

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -3,6 +3,7 @@ package osc
 import (
 	"bufio"
 	"bytes"
+	"math/rand"
 	"net"
 	"reflect"
 	"strconv"
@@ -130,7 +131,7 @@ func serveUntilInterrupted(server *Server) error {
 	return nil
 }
 
-func TestServerMessageDispatching(t *testing.T) {
+func testServerMessageDispatching(t *testing.T, stringArgument string) {
 	finish := make(chan bool)
 	start := make(chan bool)
 	done := sync.WaitGroup{}
@@ -150,12 +151,26 @@ func TestServerMessageDispatching(t *testing.T) {
 				finish <- true
 			}()
 
-			if len(msg.Arguments) != 1 {
-				t.Error("Argument length should be 1 and is: " + string(len(msg.Arguments)))
+			if len(msg.Arguments) != 2 {
+				t.Error("Argument length should be 2 and is: " + string(len(msg.Arguments)))
 			}
 
 			if msg.Arguments[0].(int32) != 1122 {
 				t.Error("Argument should be 1122 and is: " + string(msg.Arguments[0].(int32)))
+			}
+
+			receivedString := msg.Arguments[1].(string)
+
+			if len(receivedString) != len(stringArgument) {
+				t.Errorf(
+					"String argument length should be %d and is %d",
+					len(stringArgument),
+					len(receivedString),
+				)
+			} else if receivedString != stringArgument {
+				t.Errorf(
+					"Argument should be %s and is: %s", stringArgument, receivedString,
+				)
 			}
 		},
 	); err != nil {
@@ -181,6 +196,7 @@ func TestServerMessageDispatching(t *testing.T) {
 			client := NewClient("localhost", port)
 			msg := NewMessage("/address/test")
 			msg.Append(int32(1122))
+			msg.Append(stringArgument)
 			if err := client.Send(msg); err != nil {
 				t.Error(err)
 				done.Done()
@@ -201,7 +217,21 @@ func TestServerMessageDispatching(t *testing.T) {
 	done.Wait()
 }
 
-func TestServerMessageReceiving(t *testing.T) {
+func TestServerMessageDispatchingUDP(t *testing.T) {
+	// Attempting to send a message larger than this (the exact threshold depends
+	// on your OS, etc.) results in an error like:
+	//
+	//   write udp 127.0.0.1:52496->127.0.0.1:6677: write: message too long
+	//
+	// This is expected for UDP. The practical guaranteed packet size limit for
+	// UDP is 576 bytes, and some of that is taken up by protocol overhead.
+	//
+	// Reference:
+	// https://forum.juce.com/t/osc-blobs-are-lost-above-certain-size/20241/2
+	testServerMessageDispatching(t, randomString(500))
+}
+
+func testServerMessageReceiving(t *testing.T, stringArgument string) {
 	port := 6677
 
 	finish := make(chan bool)
@@ -233,14 +263,27 @@ func TestServerMessageReceiving(t *testing.T) {
 		}
 
 		msg := packet.(*Message)
-		if msg.CountArguments() != 2 {
-			t.Errorf("Argument length should be 2 and is: %d\n", msg.CountArguments())
+		if msg.CountArguments() != 3 {
+			t.Errorf("Argument length should be 3 and is: %d\n", msg.CountArguments())
 		}
 		if msg.Arguments[0].(int32) != 1122 {
 			t.Error("Argument should be 1122 and is: " + string(msg.Arguments[0].(int32)))
 		}
 		if msg.Arguments[1].(int32) != 3344 {
 			t.Error("Argument should be 3344 and is: " + string(msg.Arguments[1].(int32)))
+		}
+
+		receivedString := msg.Arguments[2].(string)
+		if len(receivedString) != len(stringArgument) {
+			t.Errorf(
+				"String argument length should be %d and is %d",
+				len(stringArgument),
+				len(receivedString),
+			)
+		} else if receivedString != stringArgument {
+			t.Errorf(
+				"Argument should be %s and is: %s", stringArgument, receivedString,
+			)
 		}
 
 		c.Close()
@@ -256,6 +299,7 @@ func TestServerMessageReceiving(t *testing.T) {
 			msg := NewMessage("/address/test")
 			msg.Append(int32(1122))
 			msg.Append(int32(3344))
+			msg.Append(stringArgument)
 			time.Sleep(500 * time.Millisecond)
 			if err := client.Send(msg); err != nil {
 				t.Error(err)
@@ -275,6 +319,32 @@ func TestServerMessageReceiving(t *testing.T) {
 	}()
 
 	done.Wait()
+}
+
+// source: https://www.calhoun.io/creating-random-strings-in-go/
+func randomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func TestServerMessageReceivingUDP(t *testing.T) {
+	// Attempting to send a message larger than this (the exact threshold depends
+	// on your OS, etc.) results in an error like:
+	//
+	//   write udp 127.0.0.1:52496->127.0.0.1:6677: write: message too long
+	//
+	// This is expected for UDP. The practical guaranteed packet size limit for
+	// UDP is 576 bytes, and some of that is taken up by protocol overhead.
+	//
+	// Reference:
+	// https://forum.juce.com/t/osc-blobs-are-lost-above-certain-size/20241/2
+	testServerMessageReceiving(t, randomString(500))
 }
 
 func TestReadTimeout(t *testing.T) {


### PR DESCRIPTION
This branch includes #39. Review and merge that one first.

Here is a smaller diff of just the commits that this branch adds: https://github.com/daveyarwood/go-osc/compare/test-improvements...randomized-string-tests

This doesn't provide much benefit on its own, but when TCP support is added (in a subsequent PR), it will enable us to test that much larger packets can be successfully sent and received over TCP.