### PR TITLE
Performance Improvements

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -177,6 +177,8 @@ func (s *StandardDispatcher) Dispatch(packet Packet) {
 // Message
 ////
 
+var str []byte
+
 // NewMessage returns a new Message. The address parameter is the OSC address.
 func NewMessage(addr string, args ...interface{}) *Message {
 	return &Message{Address: addr, Arguments: args}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -210,11 +210,7 @@ func (msg *Message) ClearData() {
 // Match returns true, if the OSC address pattern of the OSC Message matches the given
 // address. The match is case sensitive!
 func (msg *Message) Match(addr string) bool {
-	exp := getRegEx(msg.Address)
-	if exp.MatchString(addr) {
-		return true
-	}
-	return false
+	return getRegEx(msg.Address).MatchString(addr)
 }
 
 // TypeTags returns the type tag string.
@@ -223,7 +219,7 @@ func (msg *Message) TypeTags() (string, error) {
 		return "", fmt.Errorf("message is nil")
 	}
 	
-	if len(msg.Arguments) = 0 {
+	if len(msg.Arguments) == 0 {
 		return "", nil
 	}
 
@@ -301,7 +297,7 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 			return nil, fmt.Errorf("OSC - unsupported type: %T", t)
 
 		case bool:
-			if arg.(bool) == true {
+			if t == true {
 				typetags = append(typetags, 'T')
 			} else {
 				typetags = append(typetags, 'F')
@@ -348,8 +344,7 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 
 		case Timetag:
 			typetags = append(typetags, 't')
-			timeTag := arg.(Timetag)
-			b, err := timeTag.MarshalBinary()
+			b, err := t.MarshalBinary()
 			if err != nil {
 				return nil, err
 			}
@@ -699,6 +694,11 @@ func readArguments(msg *Message, reader *bytes.Buffer, start *int) error {
 		return err
 	}
 	*start += n
+	
+	// if there is no typetag, quit
+	if len(typetags) == 0 {
+		return nil
+	}
 
 	// If the typetag doesn't start with ',', it's not valid
 	if typetags[0] != ',' {
@@ -1041,7 +1041,7 @@ func getRegEx(pattern string) *regexp.Regexp {
 func getTypeTag(arg interface{}) (string, error) {
 	switch t := arg.(type) {
 	case bool:
-		if arg.(bool) {
+		if t {
 			return "T", nil
 		}
 		return "F", nil

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -221,7 +221,7 @@ func (msg *Message) TypeTags() (string, error) {
 		return "", fmt.Errorf("message is nil")
 	}
 	
-	if len(msg.Arguments = 0) {
+	if len(msg.Arguments) = 0 {
 		return "", nil
 	}
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -220,6 +220,10 @@ func (msg *Message) TypeTags() (string, error) {
 	if msg == nil {
 		return "", fmt.Errorf("message is nil")
 	}
+	
+	if len(msg.Arguments = 0) {
+		return "", nil
+	}
 
 	tags := []byte{','}
 	for _, m := range msg.Arguments {

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -225,7 +225,7 @@ func (msg *Message) TypeTags() (string, error) {
 
 	tags := []byte{','}
 	for _, m := range msg.Arguments {
-		s, err := GetTypeTag(m)
+		s, err := getTypeTag(m)
 		if err != nil {
 			return "", err
 		}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -22,7 +22,6 @@ const (
 
 var data = make([]byte, 65535)
 var buf = bytes.NewBuffer(data)
-var b = make([]byte, 1)
 
 
 // Packet is the interface for Message and Bundle.
@@ -616,26 +615,22 @@ func ParsePacket(msg string) (Packet, error) {
 
 // receivePacket receives an OSC packet from the given reader.
 func readPacket(reader *bytes.Buffer, start *int, end int) (Packet, error) {
-	//var buf []byte
-	_, err := reader.Read(b)
+	b, err := reader.ReadByte()
 	if err != nil {
 		return nil, err
 	}
-
-	err = reader.UnreadByte()
-	if err != nil {
-		return nil, err
-	}
+	
+	reader.UnreadByte()
 
 	// An OSC Message starts with a '/'
-	if b[0] == '/' {
+	if b == '/' {
 		packet, err := readMessage(reader, start)
 		if err != nil {
 			return nil, err
 		}
 		return packet, nil
 	}
-	if b[0] == '#' { // An OSC bundle starts with a '#'
+	if b == '#' { // An OSC bundle starts with a '#'
 		packet, err := readBundle(reader, start, end)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Here are a large number of performance improvements. I want to move the discussion over from #47 as it's not possible to comment on actual code in an issue.

This code is not intended to be merged, while it is functional, it is primarily for discussion. I would rather wait until the code has been restructured into separate files, as that will make it easier to digest the changes.

Just to give an idea of the performance improvement [1](#1):

| Function | ops ↑ | ns/op ↓ | B/op ↓ | allocs/op ↓ |
| :---- | ----: | --: | --: | --: |
| **`Server.ReceivePacket()`** | |
| Original | 23,005 | 60,837 | 70,080 | 18 |
| New |  1,000,000 | 1,320 | 176 | 8 |
| **`ParsePacket()`** |  |
| Original | 121,566 | 8,235 | 4,624 | 18 |
| New |  1,000,000 | 1,802 | 304 | 10 |
| **`Message.String()`** | | | |
| Original | 804,878 | 3,510| 256 | 10 |
| New |  1,000,000 | 1,585 | 128 | 5 |
| **`Message.MarshalBinary()`** | |
| Original | 1,000,000 | 1,942 | 368 | 10 |
| New |  1,000,000 | 1,219 | 296 | 6 |
| New (Light Version) | 2,091,072 | 716 | 24 | 3 |

#####  [1]: https://replit.com/@chabad360/go-osc-benchmark