### PR TITLE
Fix panic if blobLen is less than 0 + other errors

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -350,7 +350,6 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 				return nil, err
 			}
 
-		case *Timetag:
 		case Timetag:
 			typetags = append(typetags, 't')
 			timeTag := arg.(Timetag)
@@ -795,7 +794,7 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 				return nil
 			}
 			*start += 8
-			msg.Append(NewTimetagFromTimetag(tt))
+			msg.Append(*NewTimetagFromTimetag(tt))
 
 		case 'N': // nil
 			msg.Append(nil)

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -912,6 +912,10 @@ func readBlob(reader *bufio.Reader) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	n := 4 + int(blobLen)
+	
+	if blobLen < 1 || blobLen > int32(reader.Buffered()) {
+		return nil, 0, fmt.Errorf("readBlob: invalid blob length %d", blobLen)
+	}
 
 	// Read the data
 	blob := make([]byte, blobLen)

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -350,6 +350,7 @@ func (msg *Message) MarshalBinary() ([]byte, error) {
 				return nil, err
 			}
 
+		case *Timetag:
 		case Timetag:
 			typetags = append(typetags, 't')
 			timeTag := arg.(Timetag)
@@ -912,7 +913,7 @@ func readBlob(reader *bufio.Reader) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	n := 4 + int(blobLen)
-	
+
 	if blobLen < 1 || blobLen > int32(reader.Buffered()) {
 		return nil, 0, fmt.Errorf("readBlob: invalid blob length %d", blobLen)
 	}

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -722,6 +722,10 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 	}
 	*start += n
 
+	if len(typetags) == 0 {
+		return nil
+	}
+
 	// If the typetag doesn't start with ',', it's not valid
 	if typetags[0] != ',' {
 		return fmt.Errorf("unsupported type tag string %s", typetags)

--- a/osc/osc_test.go
+++ b/osc/osc_test.go
@@ -354,6 +354,34 @@ func TestReadTimeout(t *testing.T) {
 	wg.Wait()
 }
 
+func TestReadBlob(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		args    []byte
+		want    []byte
+		want1   int
+		wantErr bool
+	}{
+		{"negative value", []byte{255, 255, 255, 255}, nil, 0, true},
+		{"large value", []byte{0, 1, 17, 112}, nil, 0, true},
+		{"regular value", []byte{0, 0, 0, 1, 10, 0, 0, 0}, []byte{10}, 8, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := readBlob(bufio.NewReader(bytes.NewBuffer(tt.args)))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readBlob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("readBlob() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("readBlob() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
 func TestReadPaddedString(t *testing.T) {
 	for _, tt := range []struct {
 		buf []byte // buffer


### PR DESCRIPTION
I've been fuzzing this library (with go-fuzz) to catch some inevitable errors, just came across one.

Fixes a panic in `readBlob` when `blobLen` is less than 0. The panic can be triggered with an invalid packet that contains an `OSC-blob` with a less than zero value. However I determined that logically a length of zero is also invalid, so I've set the check to require a minimum of 1.

Additionally, I'm checking to make sure that `blobLen` is actually fits within the read packet.