### PR TITLE
Added server SendTo method

### DIFF
--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -17,6 +17,7 @@ func main() {
 		fmt.Println("Couldn't listen: ", err)
 	}
 	defer conn.Close()
+	server.SetConnection(conn)
 
 	fmt.Println("### Welcome to go-osc receiver demo")
 	fmt.Println("Press \"q\" to exit")
@@ -25,7 +26,7 @@ func main() {
 		fmt.Println("Start listening on", addr)
 
 		for {
-			packet, err := server.ReceivePacket(conn)
+			packet, err := server.ReceivePacket()
 			if err != nil {
 				fmt.Println("Server error: " + err.Error())
 				os.Exit(1)


### PR DESCRIPTION
This pull request allows bidirectional communication. To enabled this a SendTo (analogue to PacketConn.WriteTo) was added to the Server struct. Now it is possible to both send messages to a server and receive its answers on the same port.

Further changes:
* Store current connection in Server and use it. Therefor a SetConnection method was added as well and net.PacketConn parameters were removed.
* Added Server.Listen(): enable the listening port, but do not start the Serve() loop yet. Useful if you send a message before listening for responses.
* Packet.SenderAddress(): returns sender address (or nil) for the current message or bundle. This is necessary so a server can send responses to the correct address.