### PR TITLE
Refactor packet parsing

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -603,8 +603,7 @@ func (s *Server) readFromConnection(c net.PacketConn) (Packet, error) {
 		return nil, err
 	}
 
-	var start int
-	p, err := readPacket(bufio.NewReader(bytes.NewBuffer(data)), &start, n)
+    p, err := readPacket(bufio.NewReader(bytes.NewBuffer(data[0:n])))
 	if err != nil {
 		return nil, err
 	}
@@ -613,8 +612,7 @@ func (s *Server) readFromConnection(c net.PacketConn) (Packet, error) {
 
 // ParsePacket parses the given msg string and returns a Packet
 func ParsePacket(msg string) (Packet, error) {
-	var start int
-	p, err := readPacket(bufio.NewReader(bytes.NewBufferString(msg)), &start, len(msg))
+	p, err := readPacket(bufio.NewReader(bytes.NewBufferString(msg)))
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +620,7 @@ func ParsePacket(msg string) (Packet, error) {
 }
 
 // receivePacket receives an OSC packet from the given reader.
-func readPacket(reader *bufio.Reader, start *int, end int) (Packet, error) {
+func readPacket(reader *bufio.Reader) (Packet, error) {
 	//var buf []byte
 	buf, err := reader.Peek(1)
 	if err != nil {
@@ -631,14 +629,14 @@ func readPacket(reader *bufio.Reader, start *int, end int) (Packet, error) {
 
 	// An OSC Message starts with a '/'
 	if buf[0] == '/' {
-		packet, err := readMessage(reader, start)
+		packet, err := readMessage(reader)
 		if err != nil {
 			return nil, err
 		}
 		return packet, nil
 	}
 	if buf[0] == '#' { // An OSC bundle starts with a '#'
-		packet, err := readBundle(reader, start, end)
+		packet, err := readBundle(reader)
 		if err != nil {
 			return nil, err
 		}
@@ -650,13 +648,12 @@ func readPacket(reader *bufio.Reader, start *int, end int) (Packet, error) {
 }
 
 // readBundle reads an Bundle from reader.
-func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
+func readBundle(reader *bufio.Reader) (*Bundle, error) {
 	// Read the '#bundle' OSC string
-	startTag, n, err := readPaddedString(reader)
+	startTag, _, err := readPaddedString(reader)
 	if err != nil {
 		return nil, err
 	}
-	*start += n
 
 	if startTag != bundleTagString {
 		return nil, fmt.Errorf("Invalid bundle start tag: %s", startTag)
@@ -667,21 +664,19 @@ func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
 	if err := binary.Read(reader, binary.BigEndian, &timeTag); err != nil {
 		return nil, err
 	}
-	*start += 8
 
 	// Create a new bundle
 	bundle := NewBundle(timetagToTime(timeTag))
 
 	// Read until the end of the buffer
-	for *start < end {
+	for reader.Buffered() > 0 {
 		// Read the size of the bundle element
 		var length int32
 		if err := binary.Read(reader, binary.BigEndian, &length); err != nil {
 			return nil, err
 		}
-		*start += 4
 
-		p, err := readPacket(reader, start, end)
+		p, err := readPacket(reader)
 		if err != nil {
 			return nil, err
 		}
@@ -694,17 +689,16 @@ func readBundle(reader *bufio.Reader, start *int, end int) (*Bundle, error) {
 }
 
 // readMessage from `reader`.
-func readMessage(reader *bufio.Reader, start *int) (*Message, error) {
+func readMessage(reader *bufio.Reader) (*Message, error) {
 	// First, read the OSC address
-	addr, n, err := readPaddedString(reader)
+	addr, _, err := readPaddedString(reader)
 	if err != nil {
 		return nil, err
 	}
-	*start += n
 
 	// Read all arguments
 	msg := NewMessage(addr)
-	if err = readArguments(msg, reader, start); err != nil {
+	if err = readArguments(msg, reader); err != nil {
 		return nil, err
 	}
 
@@ -712,14 +706,12 @@ func readMessage(reader *bufio.Reader, start *int) (*Message, error) {
 }
 
 // readArguments from `reader` and add them to the OSC message `msg`.
-func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
+func readArguments(msg *Message, reader *bufio.Reader) error {
 	// Read the type tag string
-	var n int
-	typetags, n, err := readPaddedString(reader)
+	typetags, _, err := readPaddedString(reader)
 	if err != nil {
 		return err
 	}
-	*start += n
 
 	if len(typetags) == 0 {
 		return nil
@@ -743,7 +735,6 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if err = binary.Read(reader, binary.BigEndian, &i); err != nil {
 				return err
 			}
-			*start += 4
 			msg.Append(i)
 
 		case 'h': // int64
@@ -751,7 +742,6 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if err = binary.Read(reader, binary.BigEndian, &i); err != nil {
 				return err
 			}
-			*start += 8
 			msg.Append(i)
 
 		case 'f': // float32
@@ -759,7 +749,6 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if err = binary.Read(reader, binary.BigEndian, &f); err != nil {
 				return err
 			}
-			*start += 4
 			msg.Append(f)
 
 		case 'd': // float64/double
@@ -767,7 +756,6 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if err = binary.Read(reader, binary.BigEndian, &d); err != nil {
 				return err
 			}
-			*start += 8
 			msg.Append(d)
 
 		case 's': // string
@@ -776,16 +764,13 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if s, _, err = readPaddedString(reader); err != nil {
 				return err
 			}
-			*start += len(s) + padBytesNeeded(len(s))
 			msg.Append(s)
 
 		case 'b': // blob
 			var buf []byte
-			var n int
-			if buf, n, err = readBlob(reader); err != nil {
+			if buf, _, err = readBlob(reader); err != nil {
 				return err
 			}
-			*start += n
 			msg.Append(buf)
 
 		case 't': // OSC time tag
@@ -793,7 +778,6 @@ func readArguments(msg *Message, reader *bufio.Reader, start *int) error {
 			if err = binary.Read(reader, binary.BigEndian, &tt); err != nil {
 				return nil
 			}
-			*start += 8
 			msg.Append(*NewTimetagFromTimetag(tt))
 
 		case 'N': // nil


### PR DESCRIPTION
Removed start counter, instead create exactly sized buffer and
use bufio.Reader.Buffered() method to determine remaning bytes.

This removes a lot of complexity from packet parsing process and solves #53