### PR TITLE
Client: reuse connection rather than creating a new one for every Send()

### DIFF
--- a/examples/basic_server/basic_server.go
+++ b/examples/basic_server/basic_server.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hypebeast/go-osc/osc"
+	"github.com/samsta/go-osc/osc"
 )
 
 func indent(str string, indentLevel int) string {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hypebeast/go-osc/osc"
+	"github.com/samsta/go-osc/osc"
 )
 
 func testString() string {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -94,7 +94,11 @@ func main() {
 	}
 
 	ip := "localhost"
-	client := osc.NewClient(ip, int(port))
+	client, err := osc.NewClient(ip, int(port))
+	if err != nil {
+		fmt.Println("Error: " + err.Error())
+		os.Exit(1)
+	}
 
 	fmt.Println("### Welcome to go-osc transmitter demo")
 	fmt.Println("Please, select the OSC packet type you would like to send:")

--- a/examples/dispatching_server/dispatching_server.go
+++ b/examples/dispatching_server/dispatching_server.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/hypebeast/go-osc/osc"
+import "github.com/samsta/go-osc/osc"
 
 func main() {
 	addr := "127.0.0.1:8765"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/hypebeast/go-osc
+module github.com/samsta/go-osc
 
 go 1.16


### PR DESCRIPTION
With an OSC sniffer (Protokol) I noticed that every message is sent from a different UDP port. I figured that's not ideal as it adds extra overhead, so here's a version of the Client that creates the connection once and then reuses it.